### PR TITLE
Added SquadUP Matches + Requests sidebar functionality

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,14 +1,16 @@
 const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema({
-  username: { type: String, required: true },
-  email:    { type: String, required: true, unique: true },
-  password: { type: String, required: true },
+  username:  { type: String, required: true },
+  email:     { type: String, required: true, unique: true },
+  password:  { type: String, required: true },
   interests: [String],
   location: {
     lat: Number,
     lng: Number,
   },
+  squadRequests: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+  matches:       [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
   createdAt: {
     type: Date,
     default: Date.now,
@@ -16,3 +18,4 @@ const userSchema = new mongoose.Schema({
 });
 
 module.exports = mongoose.model('User', userSchema);
+

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,3 +1,5 @@
+console.log("✅ users.js loaded");
+
 const express = require('express');
 const router = express.Router();
 const User = require('../models/User');
@@ -14,5 +16,84 @@ router.get('/discover', async (req, res) => {
     res.status(500).json({ error: 'Server error' });
   }
 });
+
+// GET /api/users/matches/:userId
+router.get('/matches/:userId', async (req, res) => {
+  console.log("✅ /matches route triggered", req.params.userId);
+  try {
+    const currentUser = await User.findById(req.params.userId).populate('matches');
+    if (!currentUser) return res.status(404).json({ error: 'User not found' });
+
+    res.json(currentUser.matches);
+  } catch (err) {
+    console.error('Error fetching matches:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+
+// GET /api/users/requests/:userId
+router.get('/requests/:userId', async (req, res) => {
+  try {
+    const currentUser = await User.findById(req.params.userId).populate('squadRequests');
+    if (!currentUser) return res.status(404).json({ error: 'User not found' });
+
+    res.json(currentUser.squadRequests);
+  } catch (err) {
+    console.error('Error fetching squad requests:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+
+// POST /api/users/:id/squadup
+router.post('/:id/squadup', async (req, res) => {
+  try {
+    const currentUserId = req.body.currentUserId; // You must send this in the body
+    const targetUserId = req.params.id;
+
+    if (currentUserId === targetUserId) {
+      return res.status(400).json({ message: "You can't S+UP yourself." });
+    }
+
+    const currentUser = await User.findById(currentUserId);
+    const targetUser = await User.findById(targetUserId);
+
+    if (!currentUser || !targetUser) {
+      return res.status(404).json({ message: "User not found." });
+    }
+
+    // Check if target already S+UP’ed current user
+    const isMutual = targetUser.squadRequests.includes(currentUserId);
+
+    if (isMutual) {
+      // Create mutual match
+      currentUser.matches.push(targetUserId);
+      targetUser.matches.push(currentUserId);
+
+      // Remove request from targetUser's pending list
+      targetUser.squadRequests = targetUser.squadRequests.filter(
+        (id) => id.toString() !== currentUserId
+      );
+
+      await currentUser.save();
+      await targetUser.save();
+
+      return res.status(200).json({ matched: true, message: "🎉 It’s a match!" });
+    } else {
+      // Otherwise, just add request to target
+      if (!targetUser.squadRequests.includes(currentUserId)) {
+        targetUser.squadRequests.push(currentUserId);
+        await targetUser.save();
+      }
+
+      return res.status(200).json({ matched: false, message: "S+UP request sent." });
+    }
+  } catch (err) {
+    console.error("S+UP error:", err);
+    res.status(500).json({ error: "Something went wrong." });
+  }
+});
+
 
 module.exports = router;


### PR DESCRIPTION
PR introduces new matchmaking features to the homepage:

* Added "SquadUP Requests" to the left sidebar navigation.

* Clicking it fetches and displays users who’ve requested to squad up with the current user.

* Clicking the "Matches" tab now correctly displays users who have mutually squad’d up.

* Preserves existing layout and restores user grid when switching back to "Discover".

* Fixes tab-switching bugs and improves view-handling logic.

Tested:

Tested with two user accounts.

Confirmed that requests and matches are populated and fetched from MongoDB.

LocalStorage-based login context used to determine current user.

Next Steps:

Style the SquadUP Requests grid uniquely (but this is optional).

Consider adding visual badges or tags for matches.

