### PR TITLE
Add manual city/state/country input fallback in location step and add…

### DIFF
--- a/client/src/components/signupFlow/Step2GetLocation.jsx
+++ b/client/src/components/signupFlow/Step2GetLocation.jsx
@@ -1,10 +1,27 @@
-import { Typography, Button, Box } from '@mui/material';
+import { Typography, Button, Box, TextField } from '@mui/material';
+import { useState } from 'react';
 
-const Step2GetLocation = ({ formData, setFormData, onNext, onBack  }) => { 
+const Step2GetLocation = ({ formData, setFormData, onNext, onBack }) => {
+  const [manualLocation, setManualLocation] = useState({
+    city: formData.city || '',
+    state: formData.state || '',
+    country: formData.country || '',
+  });
 
+  const handleManualChange = (e) => {
+    const { name, value } = e.target;
+    const updatedLocation = { ...manualLocation, [name]: value };
+    setManualLocation(updatedLocation);
+    setFormData({
+      ...formData,
+      location: null,
+      city: updatedLocation.city,
+      state: updatedLocation.state,
+      country: updatedLocation.country,
+    });
+  };
 
   const handleGetLocation = () => {
-      
     const apiKey = import.meta.env.VITE_OPENCAGE_API_KEY;
 
     if (!navigator.geolocation) {
@@ -16,77 +33,114 @@ const Step2GetLocation = ({ formData, setFormData, onNext, onBack  }) => {
       async (position) => {
         const { latitude, longitude } = position.coords;
 
-    try {
-      const res = await fetch(`https://api.opencagedata.com/geocode/v1/json?q=${latitude}+${longitude}&key=${apiKey}`);
-      const data = await res.json();
+        try {
+          const res = await fetch(
+            `https://api.opencagedata.com/geocode/v1/json?q=${latitude}+${longitude}&key=${apiKey}`
+          );
+          const data = await res.json();
 
-      if (!data.results.length) {
-        throw new Error('No location results found');
+          if (!data.results.length) throw new Error('No location results found');
+
+          const components = data.results[0].components;
+          const city = components.city || components.town || components.village || '';
+          const state = components.state || '';
+          const country = components.country || '';
+
+          setManualLocation({ city, state, country });
+
+          setFormData({
+            ...formData,
+            location: { lat: latitude, lng: longitude },
+            city,
+            state,
+            country,
+          });
+        } catch (err) {
+          console.error('OpenCage error:', err);
+          alert('Could not determine city from location.');
+        }
+      },
+      (error) => {
+        alert('Location access denied or unavailable.');
+        console.error(error);
       }
+    );
+  };
 
-      const components = data.results[0].components;
-      const city = components.city || components.town || components.village || 'Unknown';
-      
-      setFormData({
-        ...formData,
-        location: { lat: latitude, lng: longitude },
-        city: city
-      });
+  const isLocationReady =
+    (formData.location && formData.city && formData.country) ||
+    (manualLocation.city && manualLocation.state && manualLocation.country);
 
-      
-      } catch (err) {
-        console.error('OpenCage error:', err);
-        alert('Could not determine city from location.');
-      }
-    },
-    (error) => {
-      alert('Location access denied or unavailable.');
-      console.error(error);
-    }
+  return (
+    <>
+      <Typography variant="h6" gutterBottom>
+        Where are you located?
+      </Typography>
+
+      {/* Manual Location Fields */}
+      <TextField
+        label="City"
+        name="city"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={manualLocation.city}
+        onChange={handleManualChange}
+      />
+      <TextField
+        label="State / Province"
+        name="state"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={manualLocation.state}
+        onChange={handleManualChange}
+      />
+      <TextField
+        label="Country"
+        name="country"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={manualLocation.country}
+        onChange={handleManualChange}
+      />
+
+      <Typography variant="body2" sx={{ mt: 1, mb: 2, fontStyle: 'italic', color: '#fff' }}>
+        Or...
+      </Typography>
+
+      {/* Use My Location Button */}
+      <Button
+        variant="contained"
+        sx={{ backgroundColor: 'white', color: '#b34725', mb: 2 }}
+        onClick={handleGetLocation}
+      >
+        Use My Current Location
+      </Button>
+
+      {formData.city && (
+        <Typography variant="body2" sx={{ mb: 2 }}>
+          📍 {formData.city}, {formData.state}, {formData.country}
+        </Typography>
+      )}
+
+      <Box sx={{ display: 'flex', mt: 3 }}>
+        <Button
+          variant="outlined"
+          sx={{ color: 'white', borderColor: 'white', mr: 1 }}
+          onClick={onBack}
+        >
+          Back
+        </Button>
+        <Button
+          variant="contained"
+          sx={{ backgroundColor: 'white', color: '#b34725', ml: 1 }}
+          onClick={onNext}
+          disabled={!isLocationReady}
+        >
+          Next
+        </Button>
+      </Box>
+    </>
   );
 };
-  
 
-// --------------------------- RENDER CONTENT FROM HERE DOWN -----------------------------------------------\
-      return (
-        <>
-          <Typography variant="h6" gutterBottom>
-            What is your location?
-          </Typography>
-    
-          <Button
-            variant="contained"
-            sx={{ backgroundColor: 'white', color: '#b34725', mb: 2 }}
-            onClick={handleGetLocation}
-          >
-            Use My Current Location
-          </Button>
-    
-          {formData.city && (
-            <Typography variant="body2" sx={{ mb: 2 }}>
-              {formData.city}
-            </Typography>
-)}
-
-          <Box sx={{ display: 'flex', mt: 3, }}>
-            <Button
-              variant="outlined"
-              sx={{ color: 'white', borderColor: 'white', mr: 1 }}
-              onClick={onBack}
-            >
-              Back
-            </Button>
-            <Button
-              variant="contained"
-              sx={{ backgroundColor: 'white', color: '#b34725', ml: 1 }}
-              onClick={onNext}
-              disabled={!formData.location?.lat}
-            >
-              Next
-            </Button>
-          </Box>
-        </>
-      );
-}
-
-export default Step2GetLocation
+export default Step2GetLocation;

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -331,16 +331,41 @@ const HomePage = () => {
                                             overflow: 'hidden',
                                         }}
                                     >
-                                        <CardMedia
-                                            component="div"
-                                            sx={{ height: 200 }}
-                                            image={
-                                                user.profileImageUrl
-                                                    ? `${import.meta.env.VITE_API_URL}/uploads/${user.profileImageUrl}`
-                                                    : '/placeholder-profile.png'
-                                            }
-                                            alt={`${user.username}'s profile`}
-                                        />
+                                        {/* adding a pro-banner near top right of pro users image */}
+                                        <Box sx={{ position: 'relative' }}>
+                                            {/* User Image */}
+                                            <CardMedia
+                                                component="div"
+                                                sx={{ height: 200 }}
+                                                image={
+                                                    user.profileImageUrl
+                                                        ? `${import.meta.env.VITE_API_URL}/uploads/${user.profileImageUrl}`
+                                                        : '/placeholder-profile.png'
+                                                }
+                                                alt={`${user.username}'s profile`}
+                                            />
+
+                                            {/* Pro Ribbon CSS */}
+                                            {user.isPro && (
+                                                <Box
+                                                    sx={{
+                                                        position: 'absolute',
+                                                        top: 7,
+                                                        right: -4,
+                                                        backgroundColor: '#FF5722',
+                                                        color: '#fff',
+                                                        padding: '2px 10px',
+                                                        transform: 'rotate(35deg)',
+                                                        fontWeight: 'bold',
+                                                        fontSize: '0.75rem',
+                                                        zIndex: 2,
+                                                        boxShadow: 2,
+                                                    }}
+                                                >
+                                                    PRO
+                                                </Box>
+                                            )}
+                                        </Box>
                                         <CardContent sx={{ flexGrow: 1 }}>
                                             <Box sx={{ justifyContent: 'space-evenly' }}>
                                                 <Typography variant="h5">{user.username}</Typography>


### PR DESCRIPTION
This update enhances the signup flow by allowing users to manually enter their location if geolocation fails or they choose not to share it.  
It also includes the PRO banner that shows on usercards in the grid for PROs

- Added input fields for City, State, and Country as manual fallback in Step2GetLocation.
- Retained “Use My Location” button for users who prefer automatic detection.
- Fixed API key issue causing OpenCage geolocation errors.
- Ensured the "Next" button is only enabled if either geolocation or manual input is completed.

Notes:

- This update improves accessibility and user control over their location privacy.
- Compatible with users in both the US and international regions (e.g., provinces in Canada).