### PR TITLE
Add unsquad functionality

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Ready to SquadUP?</title>
   </head>
   <body>
     <div id="root"></div>

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -224,6 +224,34 @@ router.post('/:id/decline', authenticateToken, async (req, res) => {
 });
 
 
+// POST /api/users/:id/unsquad   --- the unsquadup (after matching)
+router.post('/:id/unsquad', authenticateToken, async (req, res) => {
+  try {
+    const currentUserId = req.user.id;
+    const targetUserId = req.params.id;
+
+    const currentUser = await User.findById(currentUserId);
+    const targetUser = await User.findById(targetUserId);
+
+    if (!currentUser || !targetUser) {
+      return res.status(404).json({ message: "User not found." });
+    }
+
+    // remove each other from matches
+    currentUser.matches = currentUser.matches.filter(id => id.toString() !== targetUserId);
+    targetUser.matches = targetUser.matches.filter(id => id.toString() !== currentUserId);
+
+    await currentUser.save();
+    await targetUser.save();
+
+    return res.status(200).json({ message: "You have unsquaded." });
+  } catch (err) {
+    console.error("❌ Unsquad error:", err);
+    res.status(500).json({ error: "Failed to unsquad." });
+  }
+});
+
+
 
 
 


### PR DESCRIPTION
PR introduces the ability for matched users to "Unsquad", effectively removing each other from the matches array in MongoDB.

Updates:
Unsquad Feature
Also updated the title in index.html that reflects in the tabbar

Adds a new POST route /api/users/:id/unsquad to handle match removal.
Clicking "Unsquad" removes the match from both users and confirms success to the current user only.
Match Logic Fixes

Fixed frontend alert logic to display "🎉 It’s a match!" only when appropriate.
Corrected conditional behavior so requests and matches update in real-time.
UI Behavior

"S+UP" button now shows as "Unsquad" when users are already matched.
Cleaned up response handling for edge cases (e.g., stale match data).