### PR TITLE
Add full booking system with calendar UI and backend booking routes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,9 +3,11 @@ import SignupPage from './pages/SignupPage'
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage'
 import UserProfile from './pages/UserProfile';
+import BookingPage from './pages/BookingPage';
+import BookingDayCalendar from './components/calendar/BookingDayCalendar';
 
 function App() {
-  
+
 
   return (
     <>
@@ -15,12 +17,13 @@ function App() {
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/home" element={<HomePage />} />
           <Route path="/profile" element={<UserProfile />} />
-          
-          
-          
+
+          {/* Booking routes all handled in BookingPage */}
+          <Route path="/booking/:proId" element={<BookingPage />} />
+          <Route path="/booking/:proId/:yearMonth/:day" element={<BookingPage />} />
         </Routes>
       </Router>
-     
+
     </>
   )
 }

--- a/client/src/components/UserProfileCard.jsx
+++ b/client/src/components/UserProfileCard.jsx
@@ -8,8 +8,11 @@ import {
   Rating
 } from '@mui/material';
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 
 const UserProfileCard = ({ user, onBack }) => {
+  const navigate = useNavigate();
   const [newRating, setNewRating] = useState(5);
   const [newComment, setNewComment] = useState('');
   const currentUserId = localStorage.getItem('userId'); // or decode from JWT later
@@ -156,14 +159,25 @@ const UserProfileCard = ({ user, onBack }) => {
         <Typography variant="h6">Location</Typography>
         <Typography variant="body1">{user.location?.city || 'N/A'}</Typography>
 
-        <Button
-          variant="contained"
-          color="secondary"
-          onClick={onBack}
-          sx={{ mt: 3 }}
-        >
-          Back to Grid
-        </Button>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 3 }}>
+  <Button
+    variant="contained"
+    color="secondary"
+    onClick={onBack}
+  >
+    Back to Grid
+  </Button>
+
+  {user.isPro && (
+    <Button
+      variant="contained"
+      color="primary"
+      onClick={() => navigate(`/booking/${user._id}`)}
+    >
+      Book with Pro
+    </Button>
+  )}
+</Box>
       </Paper>
     </Box>
   );

--- a/client/src/components/calendar/BookingDayCalendar.jsx
+++ b/client/src/components/calendar/BookingDayCalendar.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Typography, Paper, Button } from '@mui/material';
+import { useParams, useNavigate } from 'react-router-dom';
+
+const hours = ['9 AM', '10 AM', '11 AM', '12 PM', '1 PM', '2 PM', '3 PM', '4 PM', '5 PM'];
+
+const BookingDayCalendar = () => {
+  const { proId, day } = useParams();
+  const navigate = useNavigate();
+  const [bookedSlots, setBookedSlots] = useState([]);
+  const [bookingStatus, setBookingStatus] = useState('');
+
+  useEffect(() => {
+    const fetchBookedSlots = async () => {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/bookings/${proId}/${day}`);
+      const data = await res.json();
+      setBookedSlots(data.bookedHours || []);
+    };
+
+    fetchBookedSlots();
+  }, [proId, day]);
+
+  const handleBook = async (hour) => {
+    const token = localStorage.getItem('token');
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/bookings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ proId, day, hour }),
+    });
+
+    const result = await res.json();
+    if (res.ok) {
+      setBookedSlots([...bookedSlots, hour]);
+      setBookingStatus(`✅ Booked ${hour} on ${day}`);
+    } else {
+      setBookingStatus(result.message || 'Booking failed');
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: '960px',
+        mx: 'auto',
+        mt: 4,
+        p: 3,
+        borderRadius: 3,
+        backgroundColor: '#f1faff',
+        boxShadow: '0 0 12px rgba(0, 0, 0, 0.1)',
+        height: 'fit-content',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h6">
+          🕒 Book a Time Slot on {day}
+        </Typography>
+        <Button
+          variant="outlined"
+          onClick={() => navigate(`/booking/${proId}`)}
+          sx={{
+            backgroundColor: '#e0f7fa',
+            borderRadius: 2,
+            px: 2,
+            py: 1,
+            boxShadow: 1,
+            fontWeight: 'bold',
+            '&:hover': {
+              backgroundColor: '#b2ebf2',
+            },
+          }}
+        >
+          ⬅️ Back to Monthly View
+        </Button>
+      </Box>
+
+      {bookingStatus && (
+        <Typography align="center" color="success.main" mb={2}>
+          {bookingStatus}
+        </Typography>
+      )}
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr', gap: 2 }}>
+        {hours.map((hour) => {
+          const isBooked = bookedSlots.includes(hour);
+          return (
+            <Paper
+              key={hour}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                p: 2,
+                backgroundColor: isBooked ? '#ddd' : '#e0f7fa',
+                opacity: isBooked ? 0.5 : 1,
+                borderRadius: 2,
+                boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+              }}
+            >
+              <Typography>{hour}</Typography>
+              <Button
+                variant="contained"
+                disabled={isBooked}
+                onClick={() => handleBook(hour)}
+              >
+                {isBooked ? 'Booked' : 'Book'}
+              </Button>
+            </Paper>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default BookingDayCalendar;

--- a/client/src/components/calendar/BookingMonthlyCalendar.jsx
+++ b/client/src/components/calendar/BookingMonthlyCalendar.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// Generate all days in a month
+const generateMonthDays = (year, month) => {
+  const start = new Date(year, month, 1);
+  const end = new Date(year, month + 1, 0);
+  const days = [];
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    days.push(new Date(d));
+  }
+  return days;
+};
+
+const BookingMonthlyCalendar = ({ proId }) => {
+  const navigate = useNavigate();
+
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const daysInMonth = generateMonthDays(year, month);
+  const firstDayOfWeek = daysInMonth[0].getDay();
+  const paddedDays = Array(firstDayOfWeek).fill(null).concat(daysInMonth);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        width: '100%',
+        mt: 4,
+        mx: 'auto',
+      }}
+    >
+      <Box
+        sx={{
+          width: '100%',
+          maxWidth: '960px',
+          p: 3,
+          backgroundColor: '#f0f4f8',
+          borderRadius: 4,
+          boxShadow: 4,
+        }}
+      >
+        <Typography variant="h6" sx={{ textAlign: 'center', mb: 3 }}>
+          📅 Select a Day to Book with Pro
+        </Typography>
+
+        {/* Weekday headers */}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(7, 1fr)',
+            mb: 1.5,
+            gap: 1,
+          }}
+        >
+          {dayNames.map((day) => (
+            <Typography
+              key={day}
+              align="center"
+              fontWeight="bold"
+              sx={{ fontSize: '1rem' }}
+            >
+              {day}
+            </Typography>
+          ))}
+        </Box>
+
+        {/* Calendar grid */}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(7, minmax(120px, 1fr))',
+            gap: 2,
+          }}
+        >
+          {paddedDays.map((day, idx) => {
+            const dayOfWeek = day?.getDay();
+            const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
+            return (
+              <Box
+                key={idx}
+                sx={{
+                  border: '1px solid #ccc',
+                  minHeight: 100,
+                  backgroundColor: day
+                    ? isWeekend
+                      ? '#f8d7da' // light red for weekend
+                      : '#e0f7fa'
+                    : 'transparent',
+                  borderRadius: 2,
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  justifyContent: 'flex-start',
+                  p: 1.5,
+                  cursor: day && !isWeekend ? 'pointer' : 'not-allowed',
+                  '&:hover': {
+                    backgroundColor: day && !isWeekend ? '#b2ebf2' : undefined,
+                  },
+                  opacity: isWeekend ? 0.5 : 1,
+                }}
+                onClick={() => {
+                  if (!day || isWeekend) return;
+                  const selectedDay = day.getDate().toString().padStart(2, '0');
+                  const selectedMonth = (day.getMonth() + 1).toString().padStart(2, '0');
+                  const selectedYear = day.getFullYear();
+                  console.log("Navigating to", `/booking/${proId}/${selectedYear}-${selectedMonth}/${selectedDay}`);
+                  navigate(`/booking/${proId}/${selectedYear}-${selectedMonth}/${selectedDay}`);
+                }}
+              >
+                <Typography variant="body2">{day ? day.getDate() : ''}</Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default BookingMonthlyCalendar;

--- a/client/src/pages/BookingPage.jsx
+++ b/client/src/pages/BookingPage.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { useParams, useLocation } from 'react-router-dom';
+import BookingMonthlyCalendar from '../components/calendar/BookingMonthlyCalendar';
+import BookingDayCalendar from '../components/calendar/BookingDayCalendar';
+
+const BookingPage = () => {
+  const { proId } = useParams();
+  const location = useLocation();
+  const [proUser, setProUser] = useState(null);
+
+  const isDayView = location.pathname.split('/').length === 5;
+
+  useEffect(() => {
+    const fetchProUser = async () => {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/users/${proId}`);
+      const data = await res.json();
+      setProUser(data);
+    };
+
+    fetchProUser();
+  }, [proId]);
+
+  return (
+    <Box sx={{ width: '100%', p: 4 }}>
+      {/* Consistent Header */}
+      <Box sx={{ width: '100%', maxWidth: '960px', mx: 'auto', mb: 3 }}>
+        <Typography
+          variant="h4"
+          sx={{
+            mb: 2,
+            textAlign: 'center',
+            backgroundColor: '#f0f4f8',
+            p: 2,
+            borderRadius: 2,
+            boxShadow: 1,
+          }}
+        >
+          Booking with {proUser?.username || '...'}
+        </Typography>
+      </Box>
+
+      {/* Conditional View */}
+      {isDayView ? (
+        <BookingDayCalendar />
+      ) : (
+        <BookingMonthlyCalendar proId={proId} />
+      )}
+    </Box>
+  );
+};
+
+export default BookingPage;

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,10 @@ const PORT = process.env.PORT || 5000;
 const userRoutes = require('./routes/users');
 app.use('/api/users', userRoutes);
 
+// *** Adding bookingRoutes (For the booking API)
+const bookingRoutes = require('./routes/booking');
+app.use('/api/bookings', bookingRoutes);
+
 // *** Serves uploaded images
 app.use('/uploads', express.static('uploads'));
 

--- a/server/models/Booking.js
+++ b/server/models/Booking.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const bookingSchema = new mongoose.Schema({
+  proId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  date: {
+    type: String, // Format: 'YYYY-MM-DD'
+    required: true
+  },
+  hour: {
+    type: String, // e.g., '9 AM', '10 AM'
+    required: true
+  },
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Booking', bookingSchema);

--- a/server/routes/booking.js
+++ b/server/routes/booking.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router();
+const Booking = require('../models/Booking');
+const { authenticateToken } = require('../middleware/auth'); // our auth middleware
+
+// POST /api/bookings - create a new booking
+router.post('/', authenticateToken, async (req, res) => {
+  try {
+    const { proId, day, hour } = req.body;
+    const userId = req.user.id; // assuming the auth middleware works here
+
+    // prevents double booking
+    const existing = await Booking.findOne({ proId, day, hour });
+    if (existing) {
+      return res.status(409).json({ message: 'This slot is already booked.' });
+    }
+
+    const booking = new Booking({ userId, proId, day, hour });
+    await booking.save();
+
+    res.status(201).json(booking);
+  } catch (err) {
+    console.error('Error creating booking:', err);
+    res.status(500).json({ message: 'Server error while booking.' });
+  }
+});
+
+// GET /api/bookings/:proId/:day - fetches the booked slots for a pro on a given day
+router.get('/:proId/:day', async (req, res) => {
+  try {
+    const { proId, day } = req.params;
+    const bookings = await Booking.find({ proId, day });
+    const bookedHours = bookings.map((b) => b.hour);
+
+    res.json({ bookedHours });
+  } catch (err) {
+    console.error('Error fetching booked slots:', err);
+    res.status(500).json({ message: 'Error fetching booked times.' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Booking Calendar UI & Logic
This PR introduces the full booking experience for users interacting with pro profiles. It includes both visual UI enhancements and foundational logic for the scheduling system.

** What's Included:
- Monthly Booking Calendar
- Grid layout for current month
- Only weekdays (Mon–Fri) are clickable
- Styled layout consistent with UserProfile and theme

** Daily Booking View
- Displays available hourly slots (9 AM – 5 PM) - from what Prabh wanted for now.. 
- Will Show booking status ("Book" / "Booked") the code is there just need to work on payments
- There will be Real-time feedback message on successful booking
- Back button to return to monthly view

** Shared Header
- "Booking with {proUser.username}" stays visible on both views (made this more complicated than needed)
- Styled to match calendar layout and centered

** Routing & Page Handling
- All booking routes handled through a single BookingPage
- Logic determines whether to show Monthly or Day view based on the URL

** Future Stripe Integration Placeholder
- Booking logic is ready for Stripe to be connected
- The pro user hourly rate is already stored in MongoDB for future pricing display

** Notes:
- The backend includes the Booking.js model and /api/bookings route but payment handling is still not completed yet.
- Everything is scoped under feature/NewUI-Bookings for better integration and testing.