### PR TITLE
Fix Stripe webhook route + add publicDir for Vite static routingin vi…

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+
+  // adding this line below for a failsafe for static webs 
+  // (redirect after stripe wasn't working for some reason)
+   publicDir: 'public',
   
   //adding  this section to route /api calls to backend
   server: {

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -4,7 +4,7 @@ const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const Booking = require('../models/Booking'); // mongodb booking model
 
 // raw body for Stripe signature verification section
-router.post('/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
+router.post('/stripe/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
     console.log('📡 Stripe webhook received!'); // ✅ moved inside the POST route
 
     const sig = req.headers['stripe-signature'];


### PR DESCRIPTION
The PR is to fix an issue with Stripe Webhook not being looked at due to static page redirect from Stripe.
Added the publicDir: 'public', in vite.confic.js to accommodate for that and then also fixed the webhook routing.
router.post was set to just ('/webhook', express.raw....)  When it should have been '/stripe/webhook'
