### PR TITLE
Fix: Mount Stripe webhook correctly under /api/stripe/webhook

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,8 @@ const io = socketIo(server, {
   }
 });
 // Webhook route
-app.use('/api', require('./routes/webhook'));
+const webhookRoutes = require('./routes/webhook');
+app.use('/api/stripe/webhook', webhookRoutes);
 
 // *** This is Middleware Setup 
 app.use(cors());

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -4,7 +4,7 @@ const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const Booking = require('../models/Booking'); // mongodb booking model
 
 // raw body for Stripe signature verification section
-router.post('/stripe/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
+router.post('/', express.raw({ type: 'application/json' }), async (req, res) => {
     console.log('📡 Stripe webhook received!'); // ✅ moved inside the POST route
 
     const sig = req.headers['stripe-signature'];


### PR DESCRIPTION
Merge fix for Stripe webhook + static redirect (booking-success)
- Fixes 404 on booking-success after Stripe redirect
- Stores booking to MongoDB after successful checkout.session
- Adds `publicDir` config to Vite for static routing support