### PR TITLE
Add Help and Settings pages with sidebar navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,8 @@ import BookingDayCalendar from './components/calendar/BookingDayCalendar';
 import MessagesPage from './pages/MessagesPage';
 import ChatRoomPage from './pages/ChatRoomPage';
 import BookingSuccess from './pages/BookingSuccess';
+import SettingsPage from './pages/SettingsPage';
+import HelpPage from './pages/HelpPage';
 
 function App() {
 
@@ -29,6 +31,13 @@ function App() {
           <Route path="/booking/:proId" element={<BookingPage />} />
           <Route path="/booking/:proId/:yearMonth/:day" element={<BookingPage />} />
           <Route path="/booking-success" element={<BookingSuccess />} />
+
+          {/* Help and Settings  */}
+
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/help" element={<HelpPage />} />
+
+
         </Routes>
       </Router>
 

--- a/client/src/components/UserMainSideBarControl.jsx
+++ b/client/src/components/UserMainSideBarControl.jsx
@@ -35,7 +35,7 @@ const UserSidebar = ({ currentUser, incomingRequests = [], setView, setTabValue,
 
       {/* Navigation Buttons */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, px: 3 }}>
-        <Button variant="outlined" sx={buttonStyle} onClick={() => {navigate('/home');}}>Home Page</Button>
+        <Button variant="outlined" sx={buttonStyle} onClick={() => { navigate('/home'); }}>Home Page</Button>
         <Button variant="outlined" sx={buttonStyle} onClick={() => navigate('/profile')}>My Profile</Button>
         <Button variant="outlined" sx={buttonStyle} onClick={() => setView?.('requests')}>
           Requests {incomingRequests.length > 0 && `(${incomingRequests.length})`}
@@ -46,10 +46,22 @@ const UserSidebar = ({ currentUser, incomingRequests = [], setView, setTabValue,
 
       {/* Bottom Section */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 'auto', p: 3 }}>
-        <Button variant="outlined" startIcon={<SettingsIcon />} sx={{ ...buttonStyle, justifyContent: 'flex-start' }} fullWidth>
+        <Button
+          variant="outlined"
+          startIcon={<SettingsIcon />}
+          sx={{ ...buttonStyle, justifyContent: 'flex-start' }}
+          fullWidth
+          onClick={() => navigate('/settings')}
+        >
           Settings
         </Button>
-        <Button variant="outlined" startIcon={<HelpIcon />} sx={{ ...buttonStyle, justifyContent: 'flex-start' }} fullWidth>
+        <Button
+          variant="outlined"
+          startIcon={<HelpIcon />}
+          sx={{ ...buttonStyle, justifyContent: 'flex-start' }}
+          fullWidth
+          onClick={() => navigate('/help')}
+        >
           Help
         </Button>
         <Button variant="outlined" startIcon={<LogoutIcon />} onClick={handleLogout} sx={{ ...buttonStyle, justifyContent: 'flex-start' }} fullWidth>

--- a/client/src/pages/HelpPage.jsx
+++ b/client/src/pages/HelpPage.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import UserSidebar from '../components/UserMainSideBarControl'; 
+import { useNavigate } from 'react-router-dom';
+
+const HelpPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <UserSidebar
+        navigate={navigate}
+        setView={() => {}}
+        setTabValue={() => {}}
+        handleLogout={() => {}} // if needed, can log or do nothing
+        currentUser={null}      // optional: or remove if the sidebar handles null fine
+        incomingRequests={[]}   // optional: or remove if the sidebar handles it fine
+      />
+
+      <Box sx={{ p: 5, flex: 1 }}>
+        <Typography variant="h3" gutterBottom>Help Center</Typography>
+        <Typography variant="body1" gutterBottom>
+          Welcome to the SquadUP Help Center! Here are some common questions:
+        </Typography>
+
+        <ul>
+          <li> How do I S+UP with someone?</li>
+          <li> How do bookings work?</li>
+          <li> How can I edit my profile?</li>
+        </ul>
+
+        <Typography variant="body2" mt={4}>
+          Still need help? Email us at <strong>support@squadup.app</strong>
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default HelpPage;
+

--- a/client/src/pages/SettingsPage.jsx
+++ b/client/src/pages/SettingsPage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Typography, Switch, FormControlLabel } from '@mui/material';
+import UserSidebar from '../components/UserMainSideBarControl';
+import { useNavigate } from 'react-router-dom';
+
+const SettingsPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <UserSidebar navigate={navigate} />
+      <Box sx={{ p: 5, flex: 1 }}>
+        <Typography variant="h3">Settings</Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default SettingsPage;


### PR DESCRIPTION
The PR adds fully functional Help and Settings pages to the SquadUP app.(minus what we need to put on them)

Both pages:
- Use the existing `UserMainSideBarControl.jsx` (sidebar) for consistent navigation
- Are now properly routed under `/help` and `/settings`
- Include sidebar navigation support using the `navigate` prop

### Help Page:
- Displays a simple FAQ and contact info
- No user-specific logic required (because all users will see the same information)

### Settings Page:
- No current layout or data on this page yet ( want to discuss what to place here, examples:
    -Blocking sction?
    -Password Reset?
    -Hide profile from grid (so they do not show to other users?) )
- Sidebar buttons all functional

## Technical Details
- Used `useNavigate()` inside each page to pass navigation to the sidebar
- Cleaned up routing in `App.jsx` to avoid crashes
- Sidebar remains reusable across pages (thanks leo!)


## Next Steps
- Flesh out Settings page logic to handle user preferences
- Possibly add animations or form inputs to Settings in future (not even sure here)