### PR TITLE
Fix message ordering by using timestamps

### DIFF
--- a/client/src/pages/ChatRoomPage.jsx
+++ b/client/src/pages/ChatRoomPage.jsx
@@ -32,7 +32,8 @@ const ChatRoomPage = () => {
     const fetchMessages = async () => {
       try {
         const res = await api.get(`/chat/message/${threadId}`);
-        setMessages(res.data);
+        const sorted = res.data.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+        setMessages(sorted);
       } catch (err) {
         console.error('Error fetching messages:', err);
       }
@@ -61,15 +62,15 @@ const ChatRoomPage = () => {
   // this useeffect scrolls to the bottom based on last message
 
   useEffect(() => {
-  const container = messageContainerRef.current;
-  if (!container) return;
+    const container = messageContainerRef.current;
+    if (!container) return;
 
-  const isNearBottom = container.scrollHeight - container.scrollTop <= container.clientHeight + 100;
+    const isNearBottom = container.scrollHeight - container.scrollTop <= container.clientHeight + 100;
 
-  if (isNearBottom) {
-    container.scrollTop = container.scrollHeight;
-  }
-}, [messages]);
+    if (isNearBottom) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, [messages]);
 
   const handleSendMessage = async (e) => {
     e.preventDefault();
@@ -134,7 +135,7 @@ const ChatRoomPage = () => {
           flexGrow: 1,
           display: 'flex',
           flexDirection: 'column',
-          
+
         }}>
           {messages.map((msg) => (
             <div

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -15,14 +15,11 @@ const MessageSchema = new mongoose.Schema({
     type: String,
     required: true
   },
-  timestamp: {
-    type: Date,
-    default: Date.now
-  },
   read: {
     type: Boolean,
     default: false
   }
-});
+}, { timestamps: true }); // this should add createdAt and updatedAt automatically to help with message consistency
 
 module.exports = mongoose.model('Message', MessageSchema);
+


### PR DESCRIPTION
This PR fixes an issue where chat messages appeared in reverse or inconsistent order when opening a chat thread. (can't believe i didn't account for this).

Changes include:

Messages are now sorted by timestamp from oldest to newest on fetch.

Ensures consistent top-to-bottom chat flow (oldest at the top, newest at the bottom).

Maintains auto-scroll behavior to the latest message when appropriate.