### PR TITLE
Feature: Sync view state with URL query param for Discover/Matches/Re…

### DIFF
--- a/client/src/components/UserMainSideBarControl.jsx
+++ b/client/src/components/UserMainSideBarControl.jsx
@@ -49,7 +49,17 @@ const UserSidebar = ({
 
       {/* Navigation Buttons */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, px: 3 }}>
-        <Button variant="outlined" sx={buttonStyle} onClick={() => { navigate('/home'); }}>Home Page</Button>
+        <Button
+          variant="outlined"
+          sx={buttonStyle}
+          onClick={() => {
+            setView?.('discover');     // Updating this because prabh wanted us to force discover view logic
+            setTabValue?.(1);          // this matches the discover tab
+            navigate('/home?view=discover');         // and keeps URL consistent
+          }}
+        >
+          Home Page
+        </Button>
         <Button variant="outlined" sx={buttonStyle} onClick={() => navigate('/profile')}>My Profile</Button>
         <Button variant="outlined" sx={buttonStyle} onClick={() => setView?.('requests')}>
           Requests {incomingRequests.length > 0 && `(${incomingRequests.length})`}
@@ -60,6 +70,7 @@ const UserSidebar = ({
           onClick={() => {
             setView?.('matches');  // trying to ensure homepage fetches matches
             setTabValue?.(2);      // and also ensure the matches tab is highlighted
+            navigate('/home?view=matches');  // trying to keep the URL updated with what prabh wanted 
           }}
         >
           Squad

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -16,6 +16,7 @@ import UserProfileCard from '../components/UserProfileCard';
 import UserSidebar from '../components/UserMainSideBarControl';
 import TabControl from '../components/TabControl';
 import api from '../api';
+import { useSearchParams } from 'react-router-dom';  // this is to help with the URL showing the tab states.
 
 // will need to refactor code later
 // this is getting a bit much on the homepage.
@@ -28,15 +29,20 @@ import api from '../api';
 const baseUrl = `${import.meta.env.VITE_API_URL}/api/users`;
 
 const HomePage = () => {
+  const [searchParams] = useSearchParams();
+  const initialView = searchParams.get('view') || 'discover';
+  const [view, setView] = useState(initialView);
+
+  const initialTab = initialView === 'matches' ? 2 : initialView === 'requests' ? null : 1;
+  const [tabValue, setTabValue] = useState(initialTab);
+
   const userId = localStorage.getItem('userId');
-  const [tabValue, setTabValue] = useState(1); // default to "Discover"
   const [users, setUsers] = useState([]);
-  const [view, setView] = useState('discover');
   const [selectedUser, setSelectedUser] = useState(null);
   const [currentUser, setCurrentUser] = useState(null);
   const [incomingRequests, setIncomingRequests] = useState([]);
-  const navigate = useNavigate();
   const [sentRequests, setSentRequests] = useState([]);
+  const navigate = useNavigate();
 
   // commenting this section out because handleTabChange, isn't being utilized after Leo created the component
   // called TabControl.jsx.  So do we still need this section?
@@ -262,6 +268,13 @@ const HomePage = () => {
   useEffect(() => {
     if (currentUser?._id) fetchRequests();
   }, [currentUser]);
+
+  // use effect to help URL maintain the tabview info
+  useEffect(() => {
+  if (view) {
+    navigate(`/home?view=${view}`, { replace: true });
+  }
+}, [view]);
 
 
   // updating the handleAccept 


### PR DESCRIPTION
This PR fixes the issue with nameless view states in the URL. 

- Initializes `view` and `tabValue` based on `?view=` in the URL
- Updates the URL automatically when view changes (e.g. tab click or sidebar click)
- Enables bookmarking and browser refresh while keeping context
- Uses `replace: true` to avoid bloating browser history on every view switch