### PR TITLE
Add: Help and Settings pages with layout and placeholder content

### DIFF
--- a/client/src/components/UserMainSideBarControl.jsx
+++ b/client/src/components/UserMainSideBarControl.jsx
@@ -49,6 +49,8 @@ const UserSidebar = ({
 
       {/* Navigation Buttons */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, px: 3 }}>
+
+        {/* Homepage Button */}
         <Button
           variant="outlined"
           sx={buttonStyle}
@@ -60,10 +62,16 @@ const UserSidebar = ({
         >
           Home Page
         </Button>
+
+        {/* MyProfile Button */}
         <Button variant="outlined" sx={buttonStyle} onClick={() => navigate('/profile')}>My Profile</Button>
+
+        {/* Requests Button */}
         <Button variant="outlined" sx={buttonStyle} onClick={() => setView?.('requests')}>
           Requests {incomingRequests.length > 0 && `(${incomingRequests.length})`}
         </Button>
+
+        {/* Squad Button */}
         <Button
           variant="outlined"
           sx={buttonStyle}
@@ -75,12 +83,16 @@ const UserSidebar = ({
         >
           Squad
         </Button>
+
+        {/* Messages Button */}
         <Button variant="outlined" sx={buttonStyle} onClick={() => navigate('/messages')}>Messages</Button>
       </Box>
 
       {/* Bottom Section */}
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 10, p: 3 }}>
+
+        {/* Settings Button */}
         <Button
           variant="outlined"
           startIcon={<SettingsIcon />}
@@ -91,6 +103,8 @@ const UserSidebar = ({
 
           Settings
         </Button>
+
+        {/* Help Button */}
         <Button
           variant="outlined"
           startIcon={<HelpIcon />}
@@ -100,6 +114,8 @@ const UserSidebar = ({
         >
           Help
         </Button>
+
+        {/* SignOut Button */}
         <Button variant="outlined" startIcon={<LogoutIcon />} onClick={handleLogout} sx={{ ...buttonStyle, justifyContent: 'flex-start' }} fullWidth>
           Sign Out
         </Button>

--- a/client/src/pages/HelpPage.jsx
+++ b/client/src/pages/HelpPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
-import UserSidebar from '../components/UserMainSideBarControl'; 
+import UserSidebar from '../components/UserMainSideBarControl';
 import { useNavigate } from 'react-router-dom';
 
 const HelpPage = () => {
@@ -12,24 +12,68 @@ const HelpPage = () => {
         navigate={navigate}
         setView={() => {}}
         setTabValue={() => {}}
-        handleLogout={() => {}} // if needed, can log or do nothing
-        currentUser={null}      // optional: or remove if the sidebar handles null fine
-        incomingRequests={[]}   // optional: or remove if the sidebar handles it fine
+        handleLogout={() => {}}
+        currentUser={null}
+        incomingRequests={[]}
       />
 
       <Box sx={{ p: 5, flex: 1 }}>
-        <Typography variant="h3" gutterBottom>Help Center</Typography>
-        <Typography variant="body1" gutterBottom>
-          Welcome to the SquadUP Help Center! Here are some common questions:
+        <Typography
+          variant="h3"
+          gutterBottom
+          sx={{ fontFamily: 'Michroma, sans-serif', color: '#000000ff' }}
+        >
+          Help Center
         </Typography>
 
-        <ul>
-          <li> How do I S+UP with someone?</li>
-          <li> How do bookings work?</li>
-          <li> How can I edit my profile?</li>
-        </ul>
+        <Typography
+          variant="body1"
+          gutterBottom
+          sx={{ fontFamily: 'Michroma, sans-serif' }}
+        >
+          Welcome to the SquadUP Help Center! Below are answers to common questions to help you get started.
+        </Typography>
 
-        <Typography variant="body2" mt={4}>
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            💬 How do I chat with someone?
+          </Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            To chat with someone, you must both be matched or on your squad. Once matched and squaded, you'll see a Chat button under their card in the Matches tab or Squad view.
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            🤝 How do I S+UP with someone?
+          </Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            Browse through Nearby or Discover users. Click “S+UP” to send a request. If they click accept on your request, it’s a match!
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            📅 How do bookings work?
+          </Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            If a user is a Pro, you can book a time slot on their calendar by clicking “Book Now” on their profile. Once confirmed, you'll receive a notification.
+          </Typography>
+        </Box>
+
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            👤 How can I edit my profile?
+          </Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'Michroma, sans-serif' }}>
+            Go to “My Profile” from the sidebar. There you can update your info, profile pictures, interests, and social links.
+          </Typography>
+        </Box>
+
+        <Typography
+          variant="body2"
+          sx={{ mt: 6, fontFamily: 'Michroma, sans-serif', color: '#777' }}
+        >
           Still need help? Email us at <strong>support@squadup.app</strong>
         </Typography>
       </Box>
@@ -38,4 +82,3 @@ const HelpPage = () => {
 };
 
 export default HelpPage;
-

--- a/client/src/pages/SettingsPage.jsx
+++ b/client/src/pages/SettingsPage.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Box, Typography, Switch, FormControlLabel } from '@mui/material';
+import {
+  Box, Typography, TextField, Button, Divider, Switch, FormControlLabel, List, ListItem, ListItemText
+} from '@mui/material';
 import UserSidebar from '../components/UserMainSideBarControl';
 import { useNavigate } from 'react-router-dom';
 
@@ -7,13 +9,75 @@ const SettingsPage = () => {
   const navigate = useNavigate();
 
   return (
-    <Box sx={{ display: 'flex' }}>
-      <UserSidebar navigate={navigate} />
-      <Box sx={{ p: 5, flex: 1 }}>
-        <Typography variant="h3">Settings</Typography>
+    <Box sx={{ display: 'flex', height: '100vh' }}>
+      <UserSidebar
+        navigate={navigate}
+        setView={() => { }}
+        setTabValue={() => { }}
+        handleLogout={() => { }}
+        currentUser={null}
+        incomingRequests={[]}
+      />
+
+      <Box sx={{ flex: 1, p: 5 }}>
+        <Typography variant="h4" sx={{ fontFamily: 'Michroma, sans-serif', mb: 3 }}>
+          Account Settings
+        </Typography>
+
+        {/* Username & Email */}
+        <Typography variant="h6" sx={{ fontFamily: 'Michroma, sans-serif' }}>Personal Information</Typography>
+        <TextField fullWidth label="Username" margin="normal" />
+        <TextField fullWidth label="Email" type="email" margin="normal" />
+        <Button variant="contained" sx={{ mt: 2 }}>Save Changes</Button>
+
+        <Divider sx={{ my: 4 }} />
+
+        {/* Password Change */}
+        <Typography variant="h6" sx={{ fontFamily: 'Michroma, sans-serif' }}>Change Password</Typography>
+        <TextField fullWidth label="Current Password" type="password" margin="normal" />
+        <TextField fullWidth label="New Password" type="password" margin="normal" />
+        <TextField fullWidth label="Confirm New Password" type="password" margin="normal" />
+        <Button variant="contained" color="warning" sx={{ mt: 2 }}>Update Password</Button>
+
+        <Divider sx={{ my: 4 }} />
+
+        {/* Blocked Users */}
+        <Typography variant="h6" sx={{ fontFamily: 'Michroma, sans-serif', mb: 1 }}>
+          Blocked Users
+        </Typography>
+
+        <Box
+          sx={{
+            maxHeight: 300,
+            overflowY: 'auto',
+            border: '1px solid #ddd',
+            borderRadius: 2,
+            p: 1,
+            backgroundColor: '#f9f9f9',
+          }}
+        >
+          <List>
+            {/* Example Blocked Users */}
+            {['User123', 'Player99', 'ToxicTim', 'SaltySarah', 'AFKAndy', 'SpammySam'].map((user, idx) => (
+              <ListItem key={idx} secondaryAction={
+                <Button color="error" variant="outlined" size="small">Unblock</Button>
+              }>
+                <ListItemText primary={user} />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+        <Divider sx={{ my: 4 }} />
+
+        {/* Delete Account */}
+        <Typography variant="h6" sx={{ fontFamily: 'Michroma, sans-serif', color: 'red' }}>Danger Zone</Typography>
+        <Button variant="outlined" color="error" sx={{ mt: 2 }}>
+          Delete My Account
+        </Button>
       </Box>
     </Box>
   );
 };
 
 export default SettingsPage;
+


### PR DESCRIPTION
 This PR introduces two new pages to improve the user experience and provide a foundation for account management:

### Help Page:
- Styled with the app’s Michroma font for consistency
- Includes helpful content for users:
- How to chat with someone
- How to S+UP and match
- How bookings work
- How to edit your profile
- Contact email for support

### Settings Page:
- Initial layout only (no functionality yet)
- Includes input fields and placeholders for:
- Username
- Email
- Change password
- Blocked users list with “Unblock” buttons
- Delete account button

