### PR TITLE
Fix: HomePage button now correctly sets tabValue to Discover

### DIFF
--- a/client/src/components/UserMainSideBarControl.jsx
+++ b/client/src/components/UserMainSideBarControl.jsx
@@ -107,9 +107,8 @@ const UserSidebar = ({ incomingRequests = [] }) => {
           variant="outlined"
           sx={buttonStyle}
           onClick={() => {
-            // setView?.('discover');     // Updating this because prabh wanted us to force discover view logic
-            // setTabValue?.(1);          // this matches the discover tab
-            navigate("/home?tabValue=1"); // and keeps URL consistent
+            setTabValue(1); // Sets the Discover tab programmatically
+            navigate("/home?tabValue=1"); // Keeps the URL in sync for shareability or refresh
           }}
         >
           Home Page


### PR DESCRIPTION
This PR is an update that ensures that clicking the Home Page button in the sidebar correctly sets the tabValue to 1 (Discover) and updates the URL to reflect that.

### Changes Made:
Updated onClick handler for the Home Page button in UserMainSideBarControl.jsx
→ Now sets setTabValue(1) and navigates to /home?tabValue=1

Ensures consistent behavior and URL state when navigating back to the Home Page

### Some Context:
Previously, navigating to the Home Page did not always default to the Discover tab since the view logic was removed and replaced with tabValue. This fix aligns the button logic with the current routing system.