### PR TITLE
fixed More button logic and reset profile view on tab change

### DIFF
--- a/client/src/components/UserCard.jsx
+++ b/client/src/components/UserCard.jsx
@@ -12,7 +12,7 @@ import {
 import { baseUrl } from "../constant";
 
 export const UserCard = (props) => {
-  const { user, type, onRemove, refreshRequests, updateRequestCount, onViewUser, } = props;
+  const { user, type, onRemove, refreshRequests, updateRequestCount, onViewUser, onStartChat, } = props;
   const { fetchUsers, fetchCurrentUser } = useContext(AppContext);
   const [sentRequests, setSentRequests] = useState([]);
   const token = localStorage.getItem("token");
@@ -218,7 +218,7 @@ export const UserCard = (props) => {
                 fontFamily: "Michroma, sans-serif",
                 fontSize: "12px",
               }}
-              onClick={() => handleStartChat(user._id)}
+              onClick={() => onStartChat?.(user._id)}
             >
               Chat
             </Button>

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -98,6 +98,11 @@ const HomePage = () => {
   }, []);
 
   useEffect(() => {
+  // this should clear selected profile when switching tabs
+  setSelectedUser(null);
+}, [tabValue]);
+
+  useEffect(() => {
     fetchUsers();
   }, [tabValue]);
 
@@ -149,6 +154,16 @@ const HomePage = () => {
   };
 
   const renderMatchesUsers = () => {
+    if (selectedUser) {
+    return (
+      <Box sx={{ flexGrow: 1, overflowY: "auto", p: 2 }}>
+        <UserProfileCard
+          user={selectedUser}
+          onBack={() => setSelectedUser(null)}
+        />
+      </Box>
+    );
+  }
     return (
       <Box
         sx={{
@@ -170,7 +185,7 @@ const HomePage = () => {
         }}
       >
         {users.map((user) => (
-          <UserCard user={user} type="matches" />
+          <UserCard key={user._id} user={user} type="matches" onViewUser={(userId) => setSelectedUser(users.find((u) => u._id === userId))} onStartChat={handleStartChat} />
         ))}
       </Box>
     );


### PR DESCRIPTION
This PR addresses UI bugs related to the “More” button and profile view behavior in the SquadUP homepage.

**Fixes:

- Clicking “More” from the Matches or Nearby tabs now properly shows the UserProfileCard
- Profile view (selectedUser) now resets when switching tabs (e.g., Discover → Matches)
- Ensures tab view and profile state don’t conflict with each other

**Additionally :

- Passed down onViewUser and onStartChat props into UserCard for consistent button functionality
- Ensured all tab views (renderDiscoverUsers, renderMatchesUsers, renderNearbyUsers) support conditional profile display