### PR TITLE
fix unsquad now deletes thread and update sidebar avatar live on prof…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,7 +16,7 @@ import RequestsPage from './pages/RequestsPage';
 import ChatPage from "./pages/ChatPage";
 
 // 👇 Create an inner component where it's safe to use useLocation
-const InnerApp = ({ isLoggedIn, tabValue, users, setTabValue, fetchUsers, fetchCurrentUser, currentUser, requestCount, fetchRequestCount, setRequestCount }) => {
+const InnerApp = ({ isLoggedIn, tabValue, users, setTabValue, fetchUsers, fetchCurrentUser, currentUser, setCurrentUser, requestCount, fetchRequestCount, setRequestCount }) => {
   const location = useLocation();
   const hideSidebarRoutes = ["/", "/login", "/signup"];
   const shouldShowSidebar = isLoggedIn && !hideSidebarRoutes.includes(location.pathname);
@@ -28,6 +28,7 @@ const InnerApp = ({ isLoggedIn, tabValue, users, setTabValue, fetchUsers, fetchC
     fetchUsers,
     fetchCurrentUser,
     currentUser,
+    setCurrentUser,
     isLoggedIn,
     requestCount,         // needed for requests counter
     setRequestCount,      // also needed for requests counter
@@ -150,9 +151,10 @@ function App() {
         fetchUsers={fetchUsers}
         fetchCurrentUser={fetchCurrentUser}
         currentUser={currentUser}
-        requestCount={requestCount} 
-        setRequestCount={setRequestCount} 
-        fetchRequestCount={fetchRequestCount} 
+        setCurrentUser={setCurrentUser}
+        requestCount={requestCount}
+        setRequestCount={setRequestCount}
+        fetchRequestCount={fetchRequestCount}
       />
     </Router>
   );

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -15,6 +15,8 @@ import { useNavigate } from "react-router-dom"; // REMOVED PARAMS BECAUSE WERE N
 import MonthlyCalendar from "../components/calendar/MonthlyCalendar"; // importing the calendar components (this is for monthly)
 import WeeklyCalendar from "../components/calendar/WeeklyCalendar"; // this is the weekly component import
 import DailyCalendar from "../components/calendar/DailyCalendar"; // this is the daily component import
+import { useContext } from "react"; // trying to get the sidebar picture to autoupdate on save click
+import AppContext from "../context/AppContext"; // trying to get the sidebar picture to autoupdate on save click
 
 const baseUrl = `${import.meta.env.VITE_API_URL}/api/users`;
 
@@ -31,6 +33,7 @@ const UserProfile = () => {
   const [showCalendar, setShowCalendar] = useState(false); // for the calendar
   const [calendarView, setCalendarView] = useState("month"); // for the calendar view.. or 'week', 'day'
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const { setCurrentUser } = useContext(AppContext);  // trying to get the sidebar picture to autoupdate on save click
 
   const [bookingMap, setBookingMap] = useState({});
 
@@ -176,6 +179,7 @@ const UserProfile = () => {
 
       const updatedUser = await res.json();
       setUser(updatedUser);
+      setCurrentUser(updatedUser); // update the global user so sidebar refreshes too
       setIsEditing(false);
       alert("Profile updated successfully!");
     } catch (err) {


### PR DESCRIPTION
This PR includes two important fixes to improve user experience and data consistency:

 1. Unsquad now deletes chat thread + messages

- When a user clicks Un-Squad, the backend now:
- Deletes the corresponding thread from MongoDB.
- Also removes all messages associated with that thread.
- This ensures that if users squad up again in the future, a fresh new thread can be created.

2. Sidebar avatar updates after profile save

- When a user updates their main profile picture on /profile:
- The avatar in the left sidebar now updates automatically (no need to refresh).
- Achieved by passing setCurrentUser from App.jsx through context and calling it after save.